### PR TITLE
DEVOPS-275 Add new jobEcsPropertiesOverride for fargate and check for…

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,6 @@ on:
       - '*.x'
   pull_request:
 
-# Laravel 12 temporarily limited to <12.38.0 due to https://github.com/orchestral/canvas/issues/47
 jobs:
   tests:
     runs-on: ubuntu-latest
@@ -15,13 +14,14 @@ jobs:
       fail-fast: false
       matrix:
         php: [8.3, 8.4]
-        laravel: ["^11.44.7", "^12.0 <12.38.0"]
+        laravel: ["^11.50.0", "^12.0"]
         dependency-version: [prefer-stable]
         include:
-          - laravel: "^12.0 <12.38.0"
-            testbench: "10.6.*"
-          - laravel: "^11.44.7"
-            testbench: "9.15.*"
+          - laravel: "^12.0"
+            testbench: "10.11.*"
+          - laravel: "^11.50.0"
+            testbench: "9.17.*"
+            no_audit: true
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 
@@ -44,7 +44,7 @@ jobs:
       - name: Install dependencies
         run: |
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
-          composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
+          composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction ${{ matrix.no_audit == true && '--no-audit' || '' }}
 
       - name: Execute tests
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,6 @@ jobs:
             testbench: "10.11.*"
           - laravel: "^11.50.0"
             testbench: "9.17.*"
-            no_audit: true
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 
@@ -44,7 +43,7 @@ jobs:
       - name: Install dependencies
         run: |
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
-          composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction ${{ matrix.no_audit == true && '--no-audit' || '' }}
+          composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
 
       - name: Execute tests
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,13 +14,11 @@ jobs:
       fail-fast: false
       matrix:
         php: [8.3, 8.4]
-        laravel: ["^11.50.0", "^12.0"]
+        laravel: ["^12.0"]
         dependency-version: [prefer-stable]
         include:
           - laravel: "^12.0"
             testbench: "10.11.*"
-          - laravel: "^11.50.0"
-            testbench: "9.17.*"
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/composer.json
+++ b/composer.json
@@ -20,17 +20,17 @@
   },
   "require": {
     "php": "^8.3|^8.4",
-    "illuminate/support": "^11.50.0|^12.61.1",
+    "illuminate/support": "^12.61.1",
     "aws/aws-sdk-php": "^3.20.6"
   },
   "require-dev": {
     "mockery/mockery": "^1.5",
-    "laravel/framework": "^11.50.0|^12.61.1",
+    "laravel/framework": "^12.61.1",
     "phpunit/phpunit": "^10.0|^11.0",
     "squizlabs/php_codesniffer": "^3.5",
     "phpstan/phpstan": "^2.1",
     "larastan/larastan": "^3.0",
-    "orchestra/testbench": "^9.17|^10.11",
+    "orchestra/testbench": "^10.11",
     "laravel/pint": "^1.25.1"
   },
   "scripts": {
@@ -38,11 +38,6 @@
     "check-style": "phpcs -p --standard=psr12 src/",
     "fix-style": "phpcbf -p --standard=psr12 src/",
     "phpstan": "phpstan analyse"
-  },
-  "config": {
-    "audit": {
-      "ignore": ["PKSA-mdq4-51ck-6kdq"]
-    }
   },
   "extra": {
     "laravel": {

--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,11 @@
     "fix-style": "phpcbf -p --standard=psr12 src/",
     "phpstan": "phpstan analyse"
   },
+  "config": {
+    "audit": {
+      "ignore": ["PKSA-mdq4-51ck-6kdq"]
+    }
+  },
   "extra": {
     "laravel": {
       "providers": [

--- a/composer.json
+++ b/composer.json
@@ -20,17 +20,17 @@
   },
   "require": {
     "php": "^8.3|^8.4",
-    "illuminate/support": "^11.44.7|^12.24.0",
+    "illuminate/support": "^11.50.0|^12.61.1",
     "aws/aws-sdk-php": "^3.20.6"
   },
   "require-dev": {
     "mockery/mockery": "^1.5",
-    "laravel/framework": "^11.44.7|^12.24.0",
+    "laravel/framework": "^11.50.0|^12.61.1",
     "phpunit/phpunit": "^10.0|^11.0",
     "squizlabs/php_codesniffer": "^3.5",
     "phpstan/phpstan": "^2.1",
     "larastan/larastan": "^3.0",
-    "orchestra/testbench": "^9.15|^10.6",
+    "orchestra/testbench": "^9.17|^10.11",
     "laravel/pint": "^1.25.1"
   },
   "scripts": {

--- a/src/Contracts/JobEcsPropertiesOverride.php
+++ b/src/Contracts/JobEcsPropertiesOverride.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * Laravel Queue for AWS Batch.
+ *
+ * @author    Luke Waite <lwaite@gmail.com>
+ * @copyright 2017 Luke Waite
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT
+ *
+ * @link      https://github.com/lukewaite/laravel-queue-aws-batch
+ */
+
+namespace LukeWaite\LaravelQueueAwsBatch\Contracts;
+
+/**
+ * Should return an array representing the contents of the ecsPropertiesOverride
+ * property documented in the AWS Batch SubmitJob API reference.
+ *
+ * Use this interface for jobs submitted to Fargate-based job queues.
+ * For EC2-based job queues, use JobContainerOverrides instead.
+ *
+ * In the event of no overrides, should return null.
+ *
+ * https://docs.aws.amazon.com/batch/latest/APIReference/API_SubmitJob.html
+ *
+ * [
+ *   "taskProperties": [
+ *     [
+ *       "containers": [
+ *         [
+ *           "name": "string",
+ *           "command": ["string"],
+ *           "environment": [
+ *             [
+ *               "name": "string",
+ *               "value": "string"
+ *             ]
+ *           ],
+ *           "resourceRequirements": [
+ *             [
+ *               "type": "MEMORY|VCPU",
+ *               "value": "string"
+ *             ]
+ *           ]
+ *         ]
+ *       ]
+ *     ]
+ *   ]
+ * ]
+ *
+ * Interface JobEcsPropertiesOverride
+ */
+interface JobEcsPropertiesOverride
+{
+    public function getBatchEcsPropertiesOverride(): ?array;
+}

--- a/src/Contracts/MultiContainerJobOverrides.php
+++ b/src/Contracts/MultiContainerJobOverrides.php
@@ -48,9 +48,9 @@ namespace LukeWaite\LaravelQueueAwsBatch\Contracts;
  *   ]
  * ]
  *
- * Interface JobEcsPropertiesOverride
+ * Interface MultiContainerJobOverrides
  */
-interface JobEcsPropertiesOverride
+interface MultiContainerJobOverrides
 {
     public function getBatchEcsPropertiesOverride(): ?array;
 }

--- a/src/Queues/BatchQueue.php
+++ b/src/Queues/BatchQueue.php
@@ -17,6 +17,7 @@ use Illuminate\Database\Connection;
 use Illuminate\Queue\DatabaseQueue;
 use Illuminate\Queue\Jobs\DatabaseJobRecord;
 use LukeWaite\LaravelQueueAwsBatch\Contracts\JobContainerOverrides;
+use LukeWaite\LaravelQueueAwsBatch\Contracts\JobEcsPropertiesOverride;
 use LukeWaite\LaravelQueueAwsBatch\Exceptions\JobNotFoundException;
 use LukeWaite\LaravelQueueAwsBatch\Exceptions\UnsupportedException;
 use LukeWaite\LaravelQueueAwsBatch\Jobs\BatchJob;
@@ -95,23 +96,27 @@ class BatchQueue extends DatabaseQueue
             ],
         ];
 
-        if (isset($job) && is_object($job) && $this->implementsJobContainerOverrides($job)) {
-            /** @var JobContainerOverrides $job */
-            $overrides = $job->getBatchContainerOverrides();
+        if (isset($job) && is_object($job)) {
+            if ($job instanceof JobEcsPropertiesOverride) {
+                /** @var JobEcsPropertiesOverride $job */
+                $overrides = $job->getBatchEcsPropertiesOverride();
 
-            if (isset($overrides)) {
-                $payload['containerOverrides'] = $overrides;
+                if (isset($overrides)) {
+                    $payload['ecsPropertiesOverride'] = $overrides;
+                }
+            } elseif ($job instanceof JobContainerOverrides) {
+                /** @var JobContainerOverrides $job */
+                $overrides = $job->getBatchContainerOverrides();
+
+                if (isset($overrides)) {
+                    $payload['containerOverrides'] = $overrides;
+                }
             }
         }
 
         $this->batch->submitJob($payload);
 
         return $jobId;
-    }
-
-    private function implementsJobContainerOverrides($job)
-    {
-        return $job instanceof JobContainerOverrides;
     }
 
     public function getJobById($id)

--- a/src/Queues/BatchQueue.php
+++ b/src/Queues/BatchQueue.php
@@ -17,7 +17,7 @@ use Illuminate\Database\Connection;
 use Illuminate\Queue\DatabaseQueue;
 use Illuminate\Queue\Jobs\DatabaseJobRecord;
 use LukeWaite\LaravelQueueAwsBatch\Contracts\JobContainerOverrides;
-use LukeWaite\LaravelQueueAwsBatch\Contracts\JobEcsPropertiesOverride;
+use LukeWaite\LaravelQueueAwsBatch\Contracts\MultiContainerJobOverrides;
 use LukeWaite\LaravelQueueAwsBatch\Exceptions\JobNotFoundException;
 use LukeWaite\LaravelQueueAwsBatch\Exceptions\UnsupportedException;
 use LukeWaite\LaravelQueueAwsBatch\Jobs\BatchJob;
@@ -97,20 +97,14 @@ class BatchQueue extends DatabaseQueue
         ];
 
         if (isset($job) && is_object($job)) {
-            if ($job instanceof JobEcsPropertiesOverride) {
-                /** @var JobEcsPropertiesOverride $job */
-                $overrides = $job->getBatchEcsPropertiesOverride();
+            [$key, $overrides] = match (true) {
+                $job instanceof MultiContainerJobOverrides => ['ecsPropertiesOverride', $job->getBatchEcsPropertiesOverride()],
+                $job instanceof JobContainerOverrides => ['containerOverrides', $job->getBatchContainerOverrides()],
+                default => [null, null],
+            };
 
-                if (isset($overrides)) {
-                    $payload['ecsPropertiesOverride'] = $overrides;
-                }
-            } elseif ($job instanceof JobContainerOverrides) {
-                /** @var JobContainerOverrides $job */
-                $overrides = $job->getBatchContainerOverrides();
-
-                if (isset($overrides)) {
-                    $payload['containerOverrides'] = $overrides;
-                }
+            if ($key !== null && isset($overrides)) {
+                $payload[$key] = $overrides;
             }
         }
 

--- a/tests/BatchQueueTest.php
+++ b/tests/BatchQueueTest.php
@@ -4,6 +4,7 @@ namespace LukeWaite\LaravelQueueAwsBatch\Tests;
 
 use Carbon\Carbon;
 use LukeWaite\LaravelQueueAwsBatch\Contracts\JobContainerOverrides;
+use LukeWaite\LaravelQueueAwsBatch\Contracts\JobEcsPropertiesOverride;
 use LukeWaite\LaravelQueueAwsBatch\Exceptions\UnsupportedException;
 use LukeWaite\LaravelQueueAwsBatch\Queues\BatchQueue;
 use Mockery\Adapter\Phpunit\MockeryTestCase as TestCase;
@@ -88,11 +89,65 @@ class BatchQueueTest extends TestCase
 
         $this->batch->shouldReceive('submitJob')->once()->andReturnUsing(function ($payload) use ($overrides) {
             $this->assertArrayHasKey('containerOverrides', $payload);
+            $this->assertArrayNotHasKey('ecsPropertiesOverride', $payload);
             $this->assertSame($overrides, $payload['containerOverrides']);
             $this->assertEquals(['jobId' => 5], $payload['parameters']);
         });
 
         $this->queue->push(new TestJobWithOverrides($overrides));
+    }
+
+    public function test_push_includes_ecs_properties_override_when_job_supports_fargate()
+    {
+        $overrides = [
+            'taskProperties' => [
+                [
+                    'containers' => [
+                        [
+                            'name' => 'main',
+                            'resourceRequirements' => [
+                                ['type' => 'VCPU', 'value' => '2'],
+                                ['type' => 'MEMORY', 'value' => '4096'],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->database->shouldReceive('table')->with('table')->andReturn($query = m::mock('StdClass'));
+        $query->shouldReceive('insertGetId')->once()->andReturn(7);
+
+        $this->batch->shouldReceive('submitJob')->once()->andReturnUsing(function ($payload) use ($overrides) {
+            $this->assertArrayHasKey('ecsPropertiesOverride', $payload);
+            $this->assertArrayNotHasKey('containerOverrides', $payload);
+            $this->assertSame($overrides, $payload['ecsPropertiesOverride']);
+            $this->assertEquals(['jobId' => 7], $payload['parameters']);
+        });
+
+        $this->queue->push(new TestFargateJobWithOverrides($overrides));
+    }
+
+    public function test_push_ecs_override_takes_precedence_over_container_overrides()
+    {
+        $ecsOverrides = [
+            'taskProperties' => [
+                [
+                    'containers' => [['name' => 'main']],
+                ],
+            ],
+        ];
+
+        $this->database->shouldReceive('table')->with('table')->andReturn($query = m::mock('StdClass'));
+        $query->shouldReceive('insertGetId')->once()->andReturn(9);
+
+        $this->batch->shouldReceive('submitJob')->once()->andReturnUsing(function ($payload) use ($ecsOverrides) {
+            $this->assertArrayHasKey('ecsPropertiesOverride', $payload);
+            $this->assertArrayNotHasKey('containerOverrides', $payload);
+            $this->assertSame($ecsOverrides, $payload['ecsPropertiesOverride']);
+        });
+
+        $this->queue->push(new TestJobWithBothOverrides($ecsOverrides));
     }
 
     public function test_get_job_by_id()
@@ -181,5 +236,30 @@ class TestJobWithOverrides implements JobContainerOverrides
     public function getBatchContainerOverrides(): ?array
     {
         return $this->overrides;
+    }
+}
+
+class TestFargateJobWithOverrides implements JobEcsPropertiesOverride
+{
+    public function __construct(private readonly array $overrides) {}
+
+    public function getBatchEcsPropertiesOverride(): ?array
+    {
+        return $this->overrides;
+    }
+}
+
+class TestJobWithBothOverrides implements JobContainerOverrides, JobEcsPropertiesOverride
+{
+    public function __construct(private readonly array $ecsOverrides) {}
+
+    public function getBatchContainerOverrides(): ?array
+    {
+        return ['vcpus' => 1];
+    }
+
+    public function getBatchEcsPropertiesOverride(): ?array
+    {
+        return $this->ecsOverrides;
     }
 }

--- a/tests/BatchQueueTest.php
+++ b/tests/BatchQueueTest.php
@@ -4,7 +4,7 @@ namespace LukeWaite\LaravelQueueAwsBatch\Tests;
 
 use Carbon\Carbon;
 use LukeWaite\LaravelQueueAwsBatch\Contracts\JobContainerOverrides;
-use LukeWaite\LaravelQueueAwsBatch\Contracts\JobEcsPropertiesOverride;
+use LukeWaite\LaravelQueueAwsBatch\Contracts\MultiContainerJobOverrides;
 use LukeWaite\LaravelQueueAwsBatch\Exceptions\UnsupportedException;
 use LukeWaite\LaravelQueueAwsBatch\Queues\BatchQueue;
 use Mockery\Adapter\Phpunit\MockeryTestCase as TestCase;
@@ -239,7 +239,7 @@ class TestJobWithOverrides implements JobContainerOverrides
     }
 }
 
-class TestFargateJobWithOverrides implements JobEcsPropertiesOverride
+class TestFargateJobWithOverrides implements MultiContainerJobOverrides
 {
     public function __construct(private readonly array $overrides) {}
 
@@ -249,7 +249,7 @@ class TestFargateJobWithOverrides implements JobEcsPropertiesOverride
     }
 }
 
-class TestJobWithBothOverrides implements JobContainerOverrides, JobEcsPropertiesOverride
+class TestJobWithBothOverrides implements JobContainerOverrides, MultiContainerJobOverrides
 {
     public function __construct(private readonly array $ecsOverrides) {}
 


### PR DESCRIPTION
… ec2 or fargate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added `MultiContainerJobOverrides` contract so jobs can provide AWS Batch ECS `ecsPropertiesOverride` data (Fargate/ECS-specific)
- Updated `src/Queues/BatchQueue.php` `pushToBatch` to include `ecsPropertiesOverride` in the AWS Batch `SubmitJob` payload when the job implements `MultiContainerJobOverrides`
- Updated override precedence in `pushToBatch`: when both `JobContainerOverrides` and `MultiContainerJobOverrides` are implemented, `ecsPropertiesOverride` is used and `containerOverrides` is omitted
- Refactored `pushToBatch` override detection/assignment using inline `match` logic
- Expanded `tests/BatchQueueTest.php` to add/adjust assertions and helper jobs verifying:
  - `ecsPropertiesOverride` is included for ECS/Fargate-capable jobs
  - `ecsPropertiesOverride` is not included when only container overrides are provided
  - ECS override takes precedence over container overrides
- Updated CI and dependencies: adjusted GitHub Actions Laravel/Testbench matrix and tightened `composer.json` Laravel/Testbench version constraints

Related JIRA issue: DEVOPS-275 (https://intouchinsight.atlassian.net/browse/DEVOPS-275)

Changes: +151 lines, -19 lines
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[DEVOPS-275]: https://intouchinsight.atlassian.net/browse/DEVOPS-275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ