### PR TITLE
IP-10636: Patch Composer security advisories

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         php: [8.3, 8.4]
         laravel: ["^12.61.1"]
-        dependency-version: [prefer-stable]
+        dependency-version: [prefer-lowest, prefer-stable]
         include:
           - laravel: "^12.61.1"
             testbench: "10.6.*"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,6 @@ on:
       - '*.x'
   pull_request:
 
-# Laravel 12 temporarily limited to <12.38.0 due to https://github.com/orchestral/canvas/issues/47
 jobs:
   tests:
     runs-on: ubuntu-latest
@@ -15,13 +14,11 @@ jobs:
       fail-fast: false
       matrix:
         php: [8.3, 8.4]
-        laravel: ["^11.44.7", "^12.0 <12.38.0"]
+        laravel: ["^12.61.1"]
         dependency-version: [prefer-stable]
         include:
-          - laravel: "^12.0 <12.38.0"
+          - laravel: "^12.61.1"
             testbench: "10.6.*"
-          - laravel: "^11.44.7"
-            testbench: "9.15.*"
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/composer.json
+++ b/composer.json
@@ -20,17 +20,17 @@
   },
   "require": {
     "php": "^8.3|^8.4",
-    "illuminate/support": "^11.44.7|^12.24.0",
-    "aws/aws-sdk-php": "^3.20.6"
+    "illuminate/support": "^12.61.1",
+    "aws/aws-sdk-php": "^3.371.4"
   },
   "require-dev": {
     "mockery/mockery": "^1.5",
-    "laravel/framework": "^11.44.7|^12.24.0",
-    "phpunit/phpunit": "^10.0|^11.0",
+    "laravel/framework": "^12.61.1",
+    "phpunit/phpunit": "^10.5.62|^11.5.50",
     "squizlabs/php_codesniffer": "^3.5",
     "phpstan/phpstan": "^2.1",
     "larastan/larastan": "^3.0",
-    "orchestra/testbench": "^9.15|^10.6",
+    "orchestra/testbench": "^10.6",
     "laravel/pint": "^1.25.1"
   },
   "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
   "require-dev": {
     "mockery/mockery": "^1.5",
     "laravel/framework": "^12.61.1",
-    "phpunit/phpunit": "^10.5.62|^11.5.50",
+    "phpunit/phpunit": "^11.5.50",
     "squizlabs/php_codesniffer": "^3.5",
     "phpstan/phpstan": "^2.1",
     "larastan/larastan": "^3.0",


### PR DESCRIPTION
## Summary

Patches Composer security advisories in this library by raising direct dependency constraint floors so even minimum-version (`--prefer-lowest`) resolution clears the affected packages. With normal resolution the project was already advisory-free; this hardens the floors consumers and CI can resolve to.

Jira: https://intouchinsight.atlassian.net/browse/IP-10636

This is a Composer library with no `composer.lock`, so the fix is constraint-only (no lockfile committed).

## Constraint bumps (old -> new)

| Package | Old | New |
| --- | --- | --- |
| `illuminate/support` | `^11.44.7\|^12.24.0` | `^12.61.1` |
| `aws/aws-sdk-php` | `^3.20.6` | `^3.371.4` |
| `laravel/framework` (dev) | `^11.44.7\|^12.24.0` | `^12.61.1` |
| `phpunit/phpunit` (dev) | `^10.0\|^11.0` | `^10.5.62\|^11.5.50` |
| `orchestra/testbench` (dev) | `^9.15\|^10.6` | `^10.6` |

## Advisories addressed (before -> after, at minimum-version resolution)

- `aws/aws-sdk-php`: URI resolution path traversal, S3 encryption key commitment, CloudFront policy document injection -> cleared
- `laravel/framework`: CRLF injection in default email rule, temporary signed URL path confusion -> cleared
- `phpunit/phpunit`: unsafe deserialization in PHPT code coverage handling (CVE-2026-24765) -> cleared

`--prefer-lowest` advisory count: **28 across 15 packages -> 19 across 11 packages**. Normal (latest) resolution: **0 advisories** (already clean, unchanged).

## Note on dropped Laravel 11 branch

The Laravel framework CRLF / signed-URL advisories are only fixed in **12.61.1+**; the entire 11.x line (latest 11.54.0 / illuminate 11.51.0) is unpatchable for them. Keeping `^11` would leave those advisories unresolvable, so the 11.x branch was dropped from `illuminate/support`, `laravel/framework`, and the matching `orchestra/testbench` `^9.x`. This narrows supported Laravel to 12.x but is the only way to clear those framework advisories.

## Unresolved (transitive-only, not directly controllable in a library)

The remaining 11 packages flagged under `--prefer-lowest` are all transitive dependencies whose floors are governed by `aws/aws-sdk-php` and the Laravel/Symfony stack, not by this library's `composer.json`:
`guzzlehttp/guzzle`, `guzzlehttp/psr7`, `mtdowling/jmespath.php`, `paragonie/random_compat`, `league/commonmark`, `psy/psysh`, `symfony/http-foundation`, `symfony/mailer`, `symfony/mime`, `symfony/routing`, `symfony/yaml`. Pinning transitive packages directly in a library is inappropriate; consumers' own lockfiles already resolve these to patched versions (latest-resolution audit is clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Updated `composer.json` dependency minimum-version constraints to remediate minimum-version (`--prefer-lowest`) security advisories, including `illuminate/support`, `aws/aws-sdk-php`, `laravel/framework` (dev), `phpunit/phpunit` (dev), and `orchestra/testbench` (dev).  
- Adjusted the CI `tests` workflow matrix to run against Laravel `^12.61.1` only (with corresponding `testbench` constraints), dropping Laravel 11 since the fixes are available starting in `12.61.1+`.  
- Kept the scope limited to dependency/CI constraint changes (no runtime code/API/script changes).  

Related JIRA issue: IP-10636 (https://intouchinsight.atlassian.net/browse/IP-10636)  

Changes: +8 lines, -11 lines
<!-- end of auto-generated comment: release notes by coderabbit.ai -->